### PR TITLE
Add Tides service and test

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
@@ -25,7 +25,8 @@ public class TidesQueryService {
     }
 
     // Documentation for endpoint is at: https://api.tidesandcurrents.noaa.gov/api/prod/
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT 
+        = "https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?application=ucsb-cs156&begin_date={beginDate}&end_date={endDate}&station={station}&product=predictions&datum=mllw&units=english&time_zone=lst_ldt&interval=hilo&format=json";
 
     public String getJSON(String beginDate, String endDate, String station) throws HttpClientErrorException {
         return "";

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
@@ -8,12 +8,20 @@ import org.springframework.web.client.RestTemplate;
 
 import lombok.extern.slf4j.Slf4j;
 
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import java.util.List;
+import java.util.Map;
 
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
 
+@Slf4j
 @Service
 public class TidesQueryService {
 
@@ -29,6 +37,18 @@ public class TidesQueryService {
         = "https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?application=ucsb-cs156&begin_date={beginDate}&end_date={endDate}&station={station}&product=predictions&datum=mllw&units=english&time_zone=lst_ldt&interval=hilo&format=json";
 
     public String getJSON(String beginDate, String endDate, String station) throws HttpClientErrorException {
-        return "";
+        log.info("beginDate={}, endDate={}, station={}", beginDate, endDate, station);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        Map<String, String> uriVariables = Map.of("beginDate", beginDate, "endDate", endDate, "station", station);
+
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
+                uriVariables);
+
+        return re.getBody();
     }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryServiceTests.java
@@ -1,0 +1,42 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(TidesQueryService.class)
+public class TidesQueryServiceTests {
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private TidesQueryService tidesQueryService;
+
+    @Test
+    public void test_getJSON(){
+        String beginDate = "20220405";
+        String endDate = "20230405";
+        String station = "9411340";
+
+        String expectedURL = TidesQueryService.ENDPOINT.replace("{beginDate}", beginDate)
+        .replace("{endDate}", endDate).replace("{station}", station);
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+            .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+            .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+            .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = tidesQueryService.getJSON(beginDate, endDate, station);
+        assertEquals(fakeJsonResult, actualResult);
+    }
+}


### PR DESCRIPTION
In this PR, we add an service that wraps the Tides API from
https://api.tidesandcurrents.noaa.gov/api/prod/datagetter

Closes #12 